### PR TITLE
Add composer.json to let PHP developers to keep track of subtotals.js on packagist.org.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+	"name": "nagarajanchinnasamy/subtotal",
+	"description": "Subtotal.js is a JavaScript plugin for PivotTable.js. It renders subtotals of rows and columns with the ability to expand and collapse rows.",
+	"authors": [
+		{
+		  "name": "Nagarajan Chinnasamy",
+		  "email": "nagarajanchinnasamy@gmail.com",
+		  "homepage": "https://github.com/nagarajanchinnasamy"
+		}
+	],
+	"keywords": [
+		"pivot",
+		"crosstab",
+		"grid",
+		"table",
+		"pivottable",
+		"pivotgrid",
+		"pivotchart",
+		"jquery",
+		"jquery-plugin",
+		"subtotal",
+		"expand",
+		"collapse",
+		"summary"
+	],
+	"type": "library",
+	"license": "MIT",
+	"minimum-stability": "stable",
+	"homepage": "http://nagarajanchinnasamy.com/subtotal",
+	"require": {
+		"nicolaskruchten/pivottable": "^2.7.0"
+	}
+}


### PR DESCRIPTION
Hello!

I would like to propose the composer.json file and ask you to add your library on packagist.org. It will be easy to PHP developer keep track of your updates and refer your library as project dependency. 

PivotTable is available on packagist too, check https://packagist.org/packages/nicolaskruchten/pivottable.

Unfortunately, all I can do is propose this file. If you agree, you have more 3 steps:

i) create packagist.org account;
ii) submit your package and
iii) wire github webhooks in packagist

After that, forget it! Your plugin will be available on packagist  and you don't need to update composer.json at each release.